### PR TITLE
mock request expects options.body to be a string. handle that.

### DIFF
--- a/lib/Http.js
+++ b/lib/Http.js
@@ -22,7 +22,11 @@ exports.Request = function() {
   };
 
   if(method === 'POST' || method === 'PUT' || method === 'PATCH' ){
-    options.body = data;
+    if (typeof data === 'object') {
+      options.body = JSON.stringify(data);
+    } else {
+      options.body = data;
+    };
   }
 
   return options;


### PR DESCRIPTION
If the request body is a (JSON) object, set `options.body` to string

@darbyfrey 
